### PR TITLE
prepare base blockchain and nodes for detest

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
 dependencies:
   override:
     - echo "Don't run npm install."
-    - sudo pip install -U fig
+    - sudo pip install -U docker-compose
 
 test:
   override:

--- a/cmd.sh
+++ b/cmd.sh
@@ -2,44 +2,67 @@
 
 cd ~/.decerver/source
 
-if [ -z $BLOCKCHAIN_ID ]; then
-  # Create our own blockchain.
-  
-  echo BLOCKCHAIN_ID not set, creating new chain.  
-  epm install --genesis contracts/genesis.json . helloworld
+echo ""
+echo ""
+echo "My environment good sir:"
+# this is here as I find it helpful for debugging, feel free to remove
+printenv
 
-  # Now we need to tell the DApp about our chain and then we’re ready to VRoom.
+echo ""
+echo ""
+echo "Am fetching the genesis block and catching up the chain."
+echo ""
+# first we need to fetch from the blockchain deployed via the
+#   erisdb container (that is a raw, no contracts, no genDoug
+#   chain).
+epm fetch --checkout --name helloworld helloworldmaster:15256
+# the sleep is here to allow epm run to connect to the peer
+#   and pull the chain.
+epm --log ${LOG_LEVEL:=3} run & sleep 2 && kill $(epm plop pid)
 
-  BLOCKCHAIN_ID=$(epm plop chainid)
+# Ensure unique key_sessions && set default local port and local_host (binding these
+#   to hostname via env vars so that the host which the peer broadcasts will operate
+#   properly and the peers can find each other as linked containers).
+key_session="$(strings /dev/urandom | grep -o '[[:alnum:]]' | head -n 10 | tr -d '\n' ; echo)"
+epm config key_session:${KEY_SESSION:=key_session} local_port:15254
+
+# when connecting to a remote chain these are the necessary minimums
+remote_host="helloworldmaster"
+remote_port="15254"
+epm config remote_host:$remote_host remote_port:$remote_port use_seed:true
+
+# now its time to install the dapp and deploy the contracts on
+#   the checked out chain.
+epm --log 4 install --no-new . helloworld
+# another small catchup command to make the chain plays nice
+#   post deployment
+epm --log ${LOG_LEVEL:=3} run & sleep 2 && kill $(epm plop pid)
+
+# Capture the primary variables
+BLOCKCHAIN_ID=$(epm plop chainid)
+if [ -z $ROOT_CONTRACT ]
+then
   ROOT_CONTRACT=$(epm plop vars | cut -d : -f 2)
-
-  epm config fetch_port:50505
-else
-  mv package.json /tmp/
-
-  jq '.module_dependencies[0].data |= . * {peer_server_address: "helloworldmaster:15256", blockchain_id: "'$BLOCKCHAIN_ID'", root_contract: "'$ROOT_CONTRACT'"}' /tmp/package.json \
-    > package.json
-
-  cd contracts
-  sleep 60
-  epm fetch --checkout --name helloworld helloworldmaster:50505
-  cd ..
-  epm install --no-new . helloworld
 fi
 
+echo ""
+echo ""
 echo "Configuring package.json with BLOCKCHAIN_ID ($BLOCKCHAIN_ID) and "
-echo "ROOT_CONTRACT ($ROOT_CONTRACT)."
+echo "ROOT_CONTRACT ($ROOT_CONTRACT) and "
+echo "PEER_SERVER ($remote_host:$remote_port)"
+mv package.json /tmp/
+jq '.module_dependencies[0].data |= . * {peer_server_address: "'$remote_host:$remote_port'", blockchain_id: "'$BLOCKCHAIN_ID'", root_contract: "'$ROOT_CONTRACT'"}' /tmp/package.json \
+    > ~/.decerver/dapps/helloworld/package.json
 
-# Configure EPM.
-
-key_session="$(strings /dev/urandom | grep -o '[[:alnum:]]' | head -n 10 | tr -d '\n' ; echo)"
-
-epm config key_session:${KEY_SESSION:=key_session} \
-  local_host:${LOCAL_HOST:=0.0.0.0} \
-  local_port:${LOCAL_PORT:=15254} \
-  max_peers:${MAX_PEERS:=10}
+echo ""
+echo ""
+echo "My package.json now looks like this."
+# this is here for debugging, feel free to remove
+cat ~/.decerver/dapps/helloworld/package.json
 
 # put the helloworld DApp in focus
+echo ""
+echo ""
+echo "Starting up! (Wheeeeeee says the marmot)"
 sleep 5 && curl http://localhost:3000/admin/switch/helloworld &
-
 decerver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,16 +8,31 @@ ipfs:
     - "4001:4001"
     - "8080:8080"
 
-# Create a Hello World instance for creating the blockain.
+# Run a blockchain only on the master.
 helloworldmaster:
+  image: eris/erisdb
+
+  expose:
+   - "15254"
+   - "15256"
+
+  environment:
+   - MASTER=true
+   - SERVE_GBLOCK=true
+   - FETCH_PORT=15256
+
+# Create a Hello World instance for writing data.
+helloworldwrite:
   build: .
+
   links:
    - compilers
    - ipfs
+   - helloworldmaster
 
   expose:
-   - "50505"
-   - "15256"
+   - "15254"
+
   ports:
    # for debugging
    - "3000:3000"
@@ -25,41 +40,26 @@ helloworldmaster:
   environment:
    - CONTAINERS=true
 
-# Create a Hello World instance for writing data.
-helloworldwrite:
+# Create a Hello World instance for reading data.
+helloworldread:
   build: .
+
   links:
    - compilers
    - ipfs
    - helloworldmaster
+   - helloworldwrite
+
+  expose:
+   - "15254"
 
   ports:
    # for debugging
    - "3001:3000"
 
   environment:
-   - CONTAINERS=true
-   - BLOCKCHAIN_ID
    - ROOT_CONTRACT
-   - REMOTE_HOST
-
-# Create a Hello World instance for reading data.
-helloworldread:
-  build: .
-  links:
-   - compilers
-   - ipfs
-   - helloworldmaster
-
-  ports:
-   # for debugging
-   - "3002:3000"
-
-  environment:
    - CONTAINERS=true
-   - BLOCKCHAIN_ID
-   - ROOT_CONTRACT
-   - REMOTE_HOST
 
 seleniumhub:
   image: selenium/hub

--- a/test.sh
+++ b/test.sh
@@ -1,14 +1,32 @@
 #!/bin/sh
-fig kill helloworldmaster helloworldwrite
-fig rm --force helloworldmaster helloworldwrite
-fig build helloworldmaster helloworldwrite
-fig up -d helloworldmaster
-helloworldmaster=$(fig ps -q helloworldmaster)
 
-export BLOCKCHAIN_ID=$(docker exec $helloworldmaster epm plop chainid)
+# convenience methods during rapid testing
+docker-compose kill helloworldwrite helloworldread
+docker-compose rm --force helloworldwrite helloworldread
+docker-compose build helloworldwrite helloworldread
 
-export ROOT_CONTRACT=$(docker exec $helloworldmaster epm plop vars \
-  | cut -d : -f 2)
+# start the background containers
+docker-compose up --no-recreate -d compilers ipfs helloworldmaster
+sleep 5 # give the master a bit of time to get everything sorted
 
-fig up -d --no-recreate seleniumnode
-# fig run helloworldtest
+# start the writer
+docker-compose up --no-recreate -d helloworldwrite
+sleep 30 # give the writer time to catch up with master and deploy contracts
+
+# grab the root contract from the writer
+helloworldwrite=$(docker-compose ps -q helloworldwrite)
+export ROOT_CONTRACT=$(docker exec $helloworldwrite echo $ROOT_CONTRACT)
+
+# helpful for debugging
+echo ""
+echo ""
+echo "Hello World Writer's DOUG Contract is at:"
+echo $ROOT_CONTRACT
+echo ""
+
+# start the reader
+docker-compose up --no-recreate helloworldread
+
+# @nodeguy not sure how you want to run the selenium tests, but its all ready for you now
+# docker-compose up -d --no-recreate seleniumnode
+# docker-compose run helloworldtest


### PR DESCRIPTION
This PR follows the following model for distributed systems testing. Three nodes have been established:

1. `helloworldmaster` -> is a blockchain only container running stock `erisdb` with minimal configuration options for a peer_server. There are three reasons for moving from a decerver master to an erisdb master. a. Was having some problems getting a decerver hosted epm to serve the genesis block. b. The master only needs to act as the relay node between the writer and the reader anyway, so no need to put a full decerver there when we only really need a chain there. c. It is a better test of the stack overall to utilize both the decerver container and the erisdb container
2. `helloworldwrite` -> is a decerver container which is linked to the master. The container fetches the chain from the master and deploys the contracts. 
3. `helloworldread` -> is a decerver container which is linked to the writer and the master. The container fetches the chain from the master and deploys the contracts (because `epm install` does this as part of its install the dapp process), however this contract is not utilized. Instead the ROOT_CONTRACT variable is passed from the writer node to the reader node and before the decerver boots up it is the ROOT_CONTRACT from the environment variables which is added to the package.json.

To accomplish this the following changes are proposed by this PR:

* start script has added a fetch to grab the chain and run the chain for a bit to let it catch up
* start script has DRY-ed up some of the variables
* the rest of the start script rework should be clear based on the above philosophy

**Note** this PR migrates the repository off of fig and onto docker-compose as EPM, 2gather, and most of our repos have been slowly migrating.