### PR TITLE
fixes for detest

### DIFF
--- a/cmd.sh
+++ b/cmd.sh
@@ -24,7 +24,8 @@ epm --log ${LOG_LEVEL:=3} run & sleep 2 && kill $(epm plop pid)
 #   to hostname via env vars so that the host which the peer broadcasts will operate
 #   properly and the peers can find each other as linked containers).
 key_session="$(strings /dev/urandom | grep -o '[[:alnum:]]' | head -n 10 | tr -d '\n' ; echo)"
-epm config key_session:${KEY_SESSION:=key_session} local_port:15254
+epm config key_session:${KEY_SESSION:=$key_session}
+epm config local_host:0.0.0.0 local_port:15254
 
 # when connecting to a remote chain these are the necessary minimums
 remote_host="helloworldmaster"
@@ -40,7 +41,7 @@ epm --log ${LOG_LEVEL:=3} run & sleep 2 && kill $(epm plop pid)
 
 # Capture the primary variables
 BLOCKCHAIN_ID=$(epm plop chainid)
-if [ -z $ROOT_CONTRACT ]
+if [ -z $ROOT_CONTRACT ] || [ $ROOT_CONTRACT == "" ]
 then
   ROOT_CONTRACT=$(epm plop vars | cut -d : -f 2)
 fi
@@ -59,6 +60,11 @@ echo ""
 echo "My package.json now looks like this."
 # this is here for debugging, feel free to remove
 cat ~/.decerver/dapps/helloworld/package.json
+
+echo ""
+echo ""
+echo "My chain config now looks like this."
+epm plop config
 
 # put the helloworld DApp in focus
 echo ""

--- a/test.sh
+++ b/test.sh
@@ -15,7 +15,7 @@ sleep 30 # give the writer time to catch up with master and deploy contracts
 
 # grab the root contract from the writer
 helloworldwrite=$(docker-compose ps -q helloworldwrite)
-export ROOT_CONTRACT=$(docker exec $helloworldwrite echo $ROOT_CONTRACT)
+export ROOT_CONTRACT=$(docker exec $helloworldwrite epm plop vars | cut -d : -f 2)
 
 # helpful for debugging
 echo ""
@@ -26,7 +26,6 @@ echo ""
 
 # start the reader
 docker-compose up --no-recreate helloworldread
-
 # @nodeguy not sure how you want to run the selenium tests, but its all ready for you now
 # docker-compose up -d --no-recreate seleniumnode
 # docker-compose run helloworldtest


### PR DESCRIPTION
changes:

* `key_session` script variable was not properly utilized -- fixed (this was the **main** problem with why the test was failing; the script was adding the string `key_session` as the key_session rather than expanding the variable so the decerver nodes had the same key and weren't communicating)
* separated out the `local_port` and `local_host` variable (style fix, non-essential)
* convenience fix on `root_contract` conditional for debug and testing (helpful when debugging on only running the reader node without wanting to add the `ROOT_CONTRACT` from the writer node as the `test.sh` file does)
* plop the blockchain's config for debugging purposes (style fix, can be removed if too verbose, but plopping config helpful to debug challenges like in bullet point 1)
* go back to old version of pulling `ROOT_CONTRACT` from writer node (the `echo` version *should* work, but was not successful for me in the testing, and the `plop` version seems to work consistently)